### PR TITLE
Add example env file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+MONGO_URI=<your MongoDB connection string>

--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ npm install mongodb
 ```
 
 Set the `MONGO_URI` environment variable or update `server.js` with your
-connection string. A sample connection string is provided below:
+connection string. A sample `.env.example` file is provided at the project root.
+Copy it to `.env` and replace the placeholder with your database URI. A sample
+connection string is shown below:
 
 ```
 mongodb+srv://iso_user:<db_password>@isoapp.i6ozni3.mongodb.net/?retryWrites=true&w=majority&appName=isoapp


### PR DESCRIPTION
## Summary
- add `.env.example` with MongoDB connection string placeholder
- document the `.env.example` file in setup instructions

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_685ac2be73a4832e9d962bdfd9ce9d35