### PR TITLE
Add Vercel config and deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,27 @@ connection string. A sample connection string is provided below:
 ```
 mongodb+srv://iso_user:<db_password>@isoapp.i6ozni3.mongodb.net/?retryWrites=true&w=majority&appName=isoapp
 ```
+
+## Environment Variables
+
+The backend expects the following environment variables when running locally or
+in production:
+
+| Variable   | Description                                   |
+| ---------- | --------------------------------------------- |
+| `MONGO_URI`| MongoDB connection string **(required)**       |
+| `PORT`     | Port the server listens on (defaults to `5000`)|
+
+Ensure these are configured in your environment or in the Vercel dashboard
+when deploying.
+
+## Deploying to Vercel
+
+1. [Sign up](https://vercel.com/signup) for a Vercel account and install the
+   GitHub integration.
+2. Import this repository into Vercel and set the `MONGO_URI` environment
+   variable in the project settings.
+3. Vercel will detect the `vercel.json` file and build the API using
+   `backend/server.js` as the entry point.
+4. After the build completes, Vercel provides a unique deployment URL such as
+   `https://your-project-name.vercel.app` which you can use to access the API.

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "version": 2,
+  "builds": [{ "src": "backend/server.js", "use": "@vercel/node" }],
+  "routes": [{ "src": "/(.*)", "dest": "backend/server.js" }]
+}


### PR DESCRIPTION
## Summary
- add `vercel.json` with backend entry point
- document required environment variables
- add instructions for deploying to Vercel

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685ac2bdc53c832eaa242baa9565ad32