### PR TITLE
Add simple dashboard UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ npm start
 
 The server will start on port 5000.
 
-Open your browser to `http://localhost:5000/` to view the static welcome page.
+Open your browser to `http://localhost:5000/` to view the dashboard that lists
+leads and merchants from the API.
 
 ## Connecting to MongoDB Atlas
 

--- a/backend/public/index.html
+++ b/backend/public/index.html
@@ -3,10 +3,64 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>ISO Tracker</title>
+  <title>ISO Tracker Dashboard</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
 </head>
 <body>
-  <h1>Welcome to ISO Tracker</h1>
-  <p>The API is available under /api.</p>
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-4">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="#">ISO Tracker</a>
+  </div>
+</nav>
+<div class="container">
+  <h1 class="mb-4">Dashboard</h1>
+  <div class="row">
+    <div class="col-md-6 mb-4">
+      <h2>Leads</h2>
+      <table class="table table-bordered" id="leads-table">
+        <thead class="table-light">
+          <tr><th>Name</th><th>Email</th><th>Phone</th><th>Status</th></tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </div>
+    <div class="col-md-6 mb-4">
+      <h2>Merchants</h2>
+      <table class="table table-bordered" id="merchants-table">
+        <thead class="table-light">
+          <tr><th>Name</th><th>MID</th><th>Processor</th><th>Status</th></tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </div>
+  </div>
+</div>
+
+<script>
+async function loadLeads() {
+  const res = await fetch('/api/leads');
+  const leads = await res.json();
+  const tbody = document.querySelector('#leads-table tbody');
+  leads.forEach(l => {
+    const row = document.createElement('tr');
+    row.innerHTML = `<td>${l.name}</td><td>${l.email || ''}</td><td>${l.phone || ''}</td><td>${l.status}</td>`;
+    tbody.appendChild(row);
+  });
+}
+
+async function loadMerchants() {
+  const res = await fetch('/api/merchants');
+  const merchants = await res.json();
+  const tbody = document.querySelector('#merchants-table tbody');
+  merchants.forEach(m => {
+    const row = document.createElement('tr');
+    row.innerHTML = `<td>${m.name}</td><td>${m.mid || ''}</td><td>${m.processor || ''}</td><td>${m.status || ''}</td>`;
+    tbody.appendChild(row);
+  });
+}
+
+loadLeads();
+loadMerchants();
+</script>
 </body>
 </html>

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import cors from 'cors';
 import mongoose from 'mongoose';
+import path from 'path';
 import leadRoutes from './routes/leads.js';
 import merchantRoutes from './routes/merchants.js';
 
@@ -14,7 +15,7 @@ app.use('/api/leads', leadRoutes);
 app.use('/api/merchants', merchantRoutes);
 
 app.get('/', (req, res) => {
-  res.json({ message: 'ISO Tracker API' });
+  res.sendFile(path.resolve('public', 'index.html'));
 });
 
 const MONGO_URI = process.env.MONGO_URI;


### PR DESCRIPTION
## Summary
- update README instructions to reference the dashboard
- serve index.html on the root route
- create a bootstrap-based dashboard

## Testing
- `npm install`
- `npm start` (terminated after launch)

------
https://chatgpt.com/codex/tasks/task_e_685ac5b023e0832eb50a1264bc63236a