### PR TITLE
Add catch-all route for dashboard

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -18,6 +18,11 @@ app.get('/', (req, res) => {
   res.sendFile(path.resolve('public', 'index.html'));
 });
 
+// Serve index.html for any other non-API route
+app.get('*', (req, res) => {
+  res.sendFile(path.resolve('public', 'index.html'));
+});
+
 const MONGO_URI = process.env.MONGO_URI;
 
 if (MONGO_URI && !MONGO_URI.includes('<db_password>')) {


### PR DESCRIPTION
## Summary
- serve `index.html` for any non-API path

## Testing
- `npm install`
- `node server.js` (manual)
- `curl -I http://localhost:5000/other`

------
https://chatgpt.com/codex/tasks/task_e_685ac6db7368832e81cf9fb56844e603