### PR TITLE
Fix missing static files on Vercel

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,10 @@
 {
   "version": 2,
+  "functions": {
+    "backend/server.js": {
+      "includeFiles": "backend/public/**"
+    }
+  },
   "builds": [{ "src": "backend/server.js", "use": "@vercel/node" }],
   "routes": [{ "src": "/(.*)", "dest": "backend/server.js" }]
 }


### PR DESCRIPTION
## Summary
- include the `backend/public` directory in the Vercel serverless function

## Testing
- `npm install`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_685ac972f030832ea493be9b4b3f8d1f