### PR TITLE
Fix static file path resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ npm install
 npm start
 ```
 
-The server will start on port 5000.
+The server will start on port 5000. Because static files are resolved relative to
+`backend/server.js`, you can also run the server from the project root using
+`node backend/server.js` without encountering missing file errors.
 
 Open your browser to `http://localhost:5000/` to view the dashboard that lists
 leads and merchants from the API.

--- a/backend/server.js
+++ b/backend/server.js
@@ -2,25 +2,28 @@ import express from 'express';
 import cors from 'cors';
 import mongoose from 'mongoose';
 import path from 'path';
+import { fileURLToPath } from 'url';
 import leadRoutes from './routes/leads.js';
 import merchantRoutes from './routes/merchants.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const app = express();
 
 app.use(cors());
 app.use(express.json());
-app.use(express.static('public'));
+app.use(express.static(path.join(__dirname, 'public')));
 
 app.use('/api/leads', leadRoutes);
 app.use('/api/merchants', merchantRoutes);
 
 app.get('/', (req, res) => {
-  res.sendFile(path.resolve('public', 'index.html'));
+  res.sendFile(path.join(__dirname, 'public', 'index.html'));
 });
 
 // Serve index.html for any other non-API route
 app.get('*', (req, res) => {
-  res.sendFile(path.resolve('public', 'index.html'));
+  res.sendFile(path.join(__dirname, 'public', 'index.html'));
 });
 
 const MONGO_URI = process.env.MONGO_URI;


### PR DESCRIPTION
## Summary
- ensure static files resolve relative to `server.js`
- document absolute path behaviour in README

## Testing
- `npm test` *(fails: Missing script)*
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_e_685ad599072c832e8f74c279155498bc