### PR TITLE
Fix Vercel routing

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -1,0 +1,2 @@
+import app from '../backend/server.js';
+export default app;

--- a/vercel.json
+++ b/vercel.json
@@ -1,10 +1,10 @@
 {
   "version": 2,
   "functions": {
-    "backend/server.js": {
+    "api/index.js": {
       "includeFiles": "backend/public/**"
     }
   },
-  "builds": [{ "src": "backend/server.js", "use": "@vercel/node" }],
-  "routes": [{ "src": "/(.*)", "dest": "backend/server.js" }]
+  "builds": [{ "src": "api/index.js", "use": "@vercel/node" }],
+  "routes": [{ "src": "/(.*)", "dest": "api/index.js" }]
 }


### PR DESCRIPTION
## Summary
- add Vercel API entrypoint to run Express server
- adjust Vercel config to use the new function

## Testing
- `node api/index.js`
- `curl -I http://localhost:5000/`

------
https://chatgpt.com/codex/tasks/task_e_685ae558e178832ea683cb6795ae52ce