### PR TITLE
Fix Vercel config error

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,6 +5,5 @@
       "includeFiles": "backend/public/**"
     }
   },
-  "builds": [{ "src": "api/index.js", "use": "@vercel/node" }],
   "routes": [{ "src": "/(.*)", "dest": "api/index.js" }]
 }


### PR DESCRIPTION
## Summary
- remove the `builds` property from `vercel.json`

This resolves the conflict between `functions` and `builds` during Vercel deployment.

## Testing
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_685ae8890394832e8b1b2afa2d0d44a4