### PR TITLE
Enable lead saving without MongoDB

### DIFF
--- a/backend/routes/leads.js
+++ b/backend/routes/leads.js
@@ -1,23 +1,42 @@
 import express from 'express';
+import mongoose from 'mongoose';
 import Lead from '../models/Lead.js';
 
 const router = express.Router();
 
 router.get('/', async (req, res) => {
-  const leads = await Lead.find();
-  res.json(leads);
+  if (req.app.locals.useMemoryDB) {
+    res.json(req.app.locals.memoryLeads);
+  } else {
+    const leads = await Lead.find();
+    res.json(leads);
+  }
 });
 
 router.post('/', async (req, res) => {
-  const lead = new Lead(req.body);
-  await lead.save();
-  res.json(lead);
+  if (req.app.locals.useMemoryDB) {
+    const lead = { _id: new mongoose.Types.ObjectId().toString(), ...req.body };
+    req.app.locals.memoryLeads.push(lead);
+    res.json(lead);
+  } else {
+    const lead = new Lead(req.body);
+    await lead.save();
+    res.json(lead);
+  }
 });
 
 router.patch('/:id', async (req, res) => {
   const { id } = req.params;
-  const lead = await Lead.findByIdAndUpdate(id, req.body, { new: true });
-  res.json(lead);
+  if (req.app.locals.useMemoryDB) {
+    const leads = req.app.locals.memoryLeads;
+    const index = leads.findIndex(l => l._id === id);
+    if (index === -1) return res.status(404).json({ error: 'Not found' });
+    leads[index] = { ...leads[index], ...req.body };
+    res.json(leads[index]);
+  } else {
+    const lead = await Lead.findByIdAndUpdate(id, req.body, { new: true });
+    res.json(lead);
+  }
 });
 
 export default router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -41,8 +41,12 @@ if (MONGO_URI && !MONGO_URI.includes('<db_password>')) {
     .catch((err) =>
       console.error('Failed to connect to MongoDB:', err.message)
     );
+  app.locals.useMemoryDB = false;
 } else {
-  console.log('No valid MongoDB connection string provided. Skipping DB connection.');
+  console.log('No valid MongoDB connection string provided. Using in-memory store.');
+  app.locals.useMemoryDB = true;
+  app.locals.memoryLeads = [];
+  app.locals.memoryMerchants = [];
 }
 
 if (!process.env.VERCEL) {


### PR DESCRIPTION
## Summary
- support saving leads when MongoDB connection isn't configured
- initialize in-memory collections in `server.js`
- update lead routes to read and write from in-memory store when used

## Testing
- `node backend/server.js` (verify server starts with in-memory store)
- `curl -X POST http://localhost:5000/api/leads -H 'Content-Type: application/json' -d '{"name":"Test Lead","email":"test@example.com"}'`
- `curl http://localhost:5000/api/leads`

------
https://chatgpt.com/codex/tasks/task_e_685b2282e9bc832ea925ff732fa2a7a3