### PR TITLE
Add seed script for sample merchant

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,14 @@ uses `dotenv` so values from `.env` are automatically loaded when you run
 ```
 mongodb+srv://iso_user:<db_password>@isoapp.i6ozni3.mongodb.net/?retryWrites=true&w=majority&appName=isoapp
 ```
+
+## Adding a sample merchant
+
+Once your `MONGO_URI` is configured you can insert a test merchant with name and email `"t"` by running the seed script:
+
+```bash
+cd backend
+npm run seed
+```
+
+The script connects to your MongoDB database and creates the merchant if it doesn't already exist.

--- a/backend/models/Merchant.js
+++ b/backend/models/Merchant.js
@@ -2,6 +2,7 @@ import mongoose from 'mongoose';
 
 const merchantSchema = new mongoose.Schema({
   name: { type: String, required: true },
+  email: String,
   mid: String,
   mcc: String,
   mtdVolume: Number,

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,8 @@
   "main": "server.js",
   "type": "module",
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "seed": "node seed.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/backend/seed.js
+++ b/backend/seed.js
@@ -1,0 +1,35 @@
+import mongoose from 'mongoose';
+import dotenv from 'dotenv';
+import Merchant from './models/Merchant.js';
+
+dotenv.config();
+
+const MONGO_URI = process.env.MONGO_URI;
+
+async function run() {
+  if (!MONGO_URI || MONGO_URI.includes('<db_password>')) {
+    console.error('Please set a valid MONGO_URI in your environment.');
+    process.exit(1);
+  }
+
+  await mongoose.connect(MONGO_URI, {
+    useNewUrlParser: true,
+    useUnifiedTopology: true,
+  });
+
+  let merchant = await Merchant.findOne({ name: 't', email: 't' });
+  if (!merchant) {
+    merchant = new Merchant({ name: 't', email: 't' });
+    await merchant.save();
+    console.log('Inserted sample merchant:', merchant);
+  } else {
+    console.log('Merchant already exists:', merchant);
+  }
+
+  await mongoose.disconnect();
+}
+
+run().catch((err) => {
+  console.error('Error running seed script:', err);
+  mongoose.disconnect();
+});


### PR DESCRIPTION
## Summary
- allow storing merchant email address
- add seed script to create a test merchant with name and email `"t"`
- expose `npm run seed`
- document how to run the seed script

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_685b43ee50f0832ea512207998bea162