### PR TITLE
Add MongoDB connection details

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,1 @@
-MONGO_URI=<your MongoDB connection string>
+MONGO_URI=mongodb+srv://iso_user:iso_pass123@isoapp.i6ozni3.mongodb.net/?retryWrites=true&w=majority&appName=isoapp

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ uses `dotenv` so values from `.env` are automatically loaded when you run
 `npm start`. A sample connection string is shown below:
 
 ```
-mongodb+srv://iso_user:<db_password>@isoapp.i6ozni3.mongodb.net/?retryWrites=true&w=majority&appName=isoapp
+mongodb+srv://iso_user:iso_pass123@isoapp.i6ozni3.mongodb.net/?retryWrites=true&w=majority&appName=isoapp
 ```
 
 ## Adding a sample merchant

--- a/backend/server.js
+++ b/backend/server.js
@@ -29,7 +29,9 @@ app.get('*', (req, res) => {
   res.sendFile(path.join(__dirname, 'public', 'index.html'));
 });
 
-const MONGO_URI = process.env.MONGO_URI;
+const MONGO_URI =
+  process.env.MONGO_URI ||
+  'mongodb+srv://iso_user:iso_pass123@isoapp.i6ozni3.mongodb.net/?retryWrites=true&w=majority&appName=isoapp';
 
 if (MONGO_URI && !MONGO_URI.includes('<db_password>')) {
   mongoose


### PR DESCRIPTION
## Summary
- include MongoDB connection string in docs
- set example `.env` with connection details
- default to MongoDB URI in backend server

## Testing
- `npm install`
- `npm install mongodb`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685b47526098832ea471a074deca60a8