### PR TITLE
Sync merchants when leads approve

### DIFF
--- a/backend/models/Lead.js
+++ b/backend/models/Lead.js
@@ -19,9 +19,7 @@ const leadSchema = new mongoose.Schema({
   varSheetUploaded: { type: Boolean, default: false },
   nmiApiKey: String,
   transacting: { type: Boolean, default: false },
-  residualsUploaded: { type: Boolean, default: false },
-  residualAuditStatus: String,
-  chargebacks: { type: Number, default: 0 }
+  approved: { type: Boolean, default: false }
 }, { timestamps: true });
 
 export default mongoose.model('Lead', leadSchema);


### PR DESCRIPTION
## Summary
- clean up `Lead` model and add boolean `approved`
- when leads are approved, automatically create merchants
- support in-memory merchant storage for testing

## Testing
- `npm install`
- `npm start` *(using memory DB)*
- `curl http://localhost:5000/api/leads`
- `curl -X POST http://localhost:5000/api/leads -d '{"name":"LeadA","approved":true,"email":"leada@example.com"}' -H 'Content-Type: application/json'`
- `curl http://localhost:5000/api/merchants`

------
https://chatgpt.com/codex/tasks/task_e_685b55d426c8832ebb81a24467c2faee