### PR TITLE
Enhance lead cards with revenue and importance

### DIFF
--- a/backend/models/Lead.js
+++ b/backend/models/Lead.js
@@ -7,6 +7,12 @@ const leadSchema = new mongoose.Schema({
   source: String,
   notes: String,
   agent: String,
+  revenueYearly: Number,
+  importance: {
+    type: String,
+    enum: ['high', 'medium', 'low'],
+    default: 'medium'
+  },
   status: {
     type: String,
     enum: ['document upload', 'application', 'pending', 'cancelled', 'approved'],

--- a/backend/public/index.html
+++ b/backend/public/index.html
@@ -199,6 +199,18 @@
                       <input id="lead-agent" class="form-control" name="agent">
                     </div>
                     <div class="mb-3">
+                      <label class="form-label">Revenue Yearly</label>
+                      <input type="number" id="lead-revenue-yearly" class="form-control" name="revenueYearly">
+                    </div>
+                    <div class="mb-3">
+                      <label class="form-label">Importance</label>
+                      <select id="lead-importance" class="form-select" name="importance">
+                        <option value="high">High</option>
+                        <option value="medium" selected>Medium</option>
+                        <option value="low">Low</option>
+                      </select>
+                    </div>
+                    <div class="mb-3">
                       <label class="form-label">Status</label>
                       <select id="lead-status" class="form-select" name="status">
                         <option value="document upload">Document Upload</option>
@@ -307,6 +319,7 @@ function colorFor(name) {
   }
   return leadColors[Math.abs(hash) % leadColors.length];
 }
+const importanceColors = { high: '#fecaca', medium: '#fef9c3', low: '#d1fae5' };
 function updateDashboardLeads(leads) {
   const list = document.getElementById('dashboard-active-leads');
   if (!list) return;
@@ -353,10 +366,12 @@ function updateDashboardMerchants(merchants) {
       if (!ul) return;
       const li = document.createElement('li');
       li.className = 'list-group-item lead-item';
-      li.textContent = l.name;
+      const rev = l.revenueYearly ? `$${l.revenueYearly}` : '';
+      const imp = l.importance || 'medium';
+      li.innerHTML = `<div>${l.name}</div><div class="text-muted small">${rev} ${imp}</div>`;
       li.draggable = true;
       li.dataset.id = l._id;
-      li.style.borderLeftColor = colorFor(l.name || '');
+      li.style.borderLeftColor = importanceColors[l.importance] || colorFor(l.name || '');
 
       li.addEventListener('dragstart', e => {
         e.dataTransfer.setData('text/plain', l._id);
@@ -370,6 +385,8 @@ function updateDashboardMerchants(merchants) {
         document.getElementById('lead-source').value = l.source || '';
         document.getElementById('lead-notes').value = l.notes || '';
         document.getElementById('lead-agent').value = l.agent || '';
+        document.getElementById('lead-revenue-yearly').value = l.revenueYearly || '';
+        document.getElementById('lead-importance').value = l.importance || 'medium';
         document.getElementById('lead-status').value = l.status || 'document upload';
         document.getElementById('lead-acquiring-bank').value = l.acquiringBank || '';
         document.getElementById('lead-docs-uploaded').checked = !!l.docsUploaded;
@@ -434,6 +451,7 @@ document.getElementById('show-add-lead').addEventListener('click', () => {
   form.reset();
   delete form.dataset.id;
   document.getElementById('lead-status').value = 'document upload';
+  document.getElementById('lead-importance').value = 'medium';
   document.getElementById('lead-docs-uploaded').checked = false;
   document.getElementById('lead-application-signed').checked = false;
   document.getElementById('lead-var-sheet-uploaded').checked = false;
@@ -446,6 +464,7 @@ document.getElementById('lead-modal-form').addEventListener('submit', async (e) 
   e.preventDefault();
   const formData = new FormData(e.target);
   const data = Object.fromEntries(formData.entries());
+  if (data.revenueYearly) data.revenueYearly = Number(data.revenueYearly);
   data.docsUploaded = document.getElementById('lead-docs-uploaded').checked;
   data.applicationSigned = document.getElementById('lead-application-signed').checked;
   data.varSheetUploaded = document.getElementById('lead-var-sheet-uploaded').checked;


### PR DESCRIPTION
## Summary
- add `revenueYearly` and `importance` fields to the Lead model
- extend lead modal with fields for revenue and importance
- color lead cards based on importance and show summary info on each card
- retain lead status updates when dragging between columns

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685b5bb4f3a4832ea0551ce87e6671ed