### PR TITLE
Fix memory DB fallback

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -33,22 +33,28 @@ const MONGO_URI =
   process.env.MONGO_URI ||
   'mongodb+srv://iso_user:iso_pass123@isoapp.i6ozni3.mongodb.net/?retryWrites=true&w=majority&appName=isoapp';
 
+app.locals.useMemoryDB = true;
+app.locals.memoryLeads = [];
+app.locals.memoryMerchants = [];
+
 if (MONGO_URI && !MONGO_URI.includes('<db_password>')) {
   mongoose
     .connect(MONGO_URI, {
       useNewUrlParser: true,
       useUnifiedTopology: true,
     })
-    .then(() => console.log('Connected to MongoDB'))
-    .catch((err) =>
-      console.error('Failed to connect to MongoDB:', err.message)
-    );
-  app.locals.useMemoryDB = false;
+    .then(() => {
+      console.log('Connected to MongoDB');
+      app.locals.useMemoryDB = false;
+    })
+    .catch((err) => {
+      console.error(
+        'Failed to connect to MongoDB, using in-memory store:',
+        err.message
+      );
+    });
 } else {
   console.log('No valid MongoDB connection string provided. Using in-memory store.');
-  app.locals.useMemoryDB = true;
-  app.locals.memoryLeads = [];
-  app.locals.memoryMerchants = [];
 }
 
 if (!process.env.VERCEL) {


### PR DESCRIPTION
## Summary
- fallback to in-memory database if MongoDB connection fails

## Testing
- `curl -s http://localhost:5000/api/leads`
- `curl -s -X POST -H 'Content-Type: application/json' -d '{"name":"Test Lead","status":"document upload"}' http://localhost:5000/api/leads`
- `curl -s -X PATCH -H 'Content-Type: application/json' -d '{"status":"approved"}' http://localhost:5000/api/leads/685b643837c4d5932c06141d`

------
https://chatgpt.com/codex/tasks/task_e_685b63af6064832e890b2a18039298b4