### PR TITLE
Fix leads page not rendering

### DIFF
--- a/backend/public/index.html
+++ b/backend/public/index.html
@@ -484,6 +484,7 @@ function updateDashboardMerchants(merchants) {
     };
     Object.values(stageMap).forEach(obj => obj.ul && (obj.ul.innerHTML = ''));
 
+    leads.forEach(l => {
       const { ul } = stageMap[l.status] || {};
       if (!ul) return;
       const li = document.createElement('li');


### PR DESCRIPTION
## Summary
- fix missing `leads.forEach` in `index.html` that broke lead rendering

## Testing
- `npm test` *(fails: Missing script)*
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_685b78d4300c832ea2d15bb23d6a26df