### PR TITLE
Adjust lead panel positioning

### DIFF
--- a/backend/public/index.html
+++ b/backend/public/index.html
@@ -146,14 +146,22 @@
     }
 
     .lead-panel {
-      width: 300px;
-      flex: 0 0 300px;
+      width: 400px;
+      flex: 0 0 400px;
       background: #fff;
       border: 1px solid #e5e7eb;
       border-radius: 8px;
       padding: 10px;
       overflow-y: auto;
-      max-height: 80vh;
+      max-height: 70vh;
+    }
+
+    #lead-stages-container {
+      flex-grow: 0;
+    }
+
+    #lead-interface {
+      display: inline-flex !important;
     }
 
   </style>
@@ -233,7 +241,7 @@
           </div>
 
           <div id="lead-interface" class="d-flex gap-3 mt-3">
-            <div class="flex-grow-1 overflow-auto">
+            <div id="lead-stages-container" class="flex-grow-1 overflow-auto">
               <div class="row text-center" id="lead-stages">
                 <div class="col">
                   <h5>Document Upload</h5>


### PR DESCRIPTION
## Summary
- tweak lead panel layout to sit directly beside status columns

## Testing
- `npm test` *(fails: Missing script)*
- `npm start` *(fails: Cannot find package 'express')*

------
https://chatgpt.com/codex/tasks/task_e_685bfc855ba8832eb50fc0dd745bf670