### PR TITLE
Fix lead panel alignment

### DIFF
--- a/backend/public/index.html
+++ b/backend/public/index.html
@@ -154,14 +154,15 @@
       padding: 10px;
       overflow-y: auto;
       max-height: 70vh;
+      margin-right: 2rem;
     }
 
     #lead-stages-container {
       flex-grow: 0;
+    }
+
     #lead-interface {
       display: inline-flex !important;
-      }
-
     }
 
   </style>


### PR DESCRIPTION
## Summary
- give the lead panel some space from the right edge
- correct CSS block for `#lead-interface`

## Testing
- `grep -n "margin-right: 2rem" -n backend/public/index.html`

------
https://chatgpt.com/codex/tasks/task_e_685c01cf4088832ebf6ee4d7807fe25c