### PR TITLE
Adjust lead panel layout and font size

### DIFF
--- a/backend/public/index.html
+++ b/backend/public/index.html
@@ -146,8 +146,8 @@
     }
 
     .lead-panel {
-      width: 400px;
-      flex: 0 0 400px;
+      width: 600px;
+      flex: 0 0 600px;
       background: #fff;
       border: 1px solid #e5e7eb;
       border-radius: 8px;
@@ -267,7 +267,7 @@
               </div>
             </div>
             <div id="lead-panel" class="lead-panel d-none">
-              <form id="lead-form" class="small">
+              <form id="lead-form">
                 <h5 class="mb-2">Lead</h5>
                 <div class="container-fluid p-0">
                   <div class="row g-2">


### PR DESCRIPTION
## Summary
- widen the lead panel to 600px so the form is more rectangular
- use the default font size on the lead form

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685c02d81670832eb2c497fd39cb6cdf