### PR TITLE
Fix lead status layout

### DIFF
--- a/backend/public/index.html
+++ b/backend/public/index.html
@@ -85,12 +85,12 @@
 
     #lead-stages {
       display: flex;
-      flex-wrap: wrap;
+      flex-wrap: nowrap;
       gap: 1rem;
     }
 
     #lead-stages .col {
-      flex: 1 1 170px;
+      flex: 1 1 150px;
       background-color: #f9fafb;
       border-radius: 8px;
       padding: 10px;
@@ -147,15 +147,16 @@
 
     .lead-panel {
       width: 100%;
-      max-width: 700px;
-      flex: 1 1 700px;
+      max-width: 360px;
+      flex: 1 1 360px;
       background: #fff;
       border: 1px solid #e5e7eb;
       border-radius: 8px;
       padding: 10px;
       overflow: visible;
       margin-right: 2rem;
-      margin-top: 0;
+      margin-top: -120px;
+      font-size: 0.8125rem;
     }
 
     #lead-stages-container {


### PR DESCRIPTION
## Summary
- keep lead status columns in a single row
- resize lead panel and raise it to align with metrics
- match lead panel font size with the rest of the page

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_685c075e19f8832e983cfb087d56c9a7