### PR TITLE
Adjust lead panel layout

### DIFF
--- a/backend/public/index.html
+++ b/backend/public/index.html
@@ -147,8 +147,8 @@
 
     .lead-panel {
       width: 100%;
-      max-width: 360px;
-      flex: 1 1 360px;
+      max-width: 720px;
+      flex: 1 1 720px;
       background: #fff;
       border: 1px solid #e5e7eb;
       border-radius: 8px;
@@ -276,19 +276,19 @@
                 <h5 class="mb-2">Lead</h5>
                 <div class="container-fluid p-0">
                   <div class="row g-2">
-                    <div class="col-md-4">
+                    <div class="col-md-6">
                       <label class="form-label">Name</label>
                       <input id="lead-name" class="form-control" name="name" required>
                     </div>
-                    <div class="col-md-4">
+                    <div class="col-md-6">
                       <label class="form-label">Email</label>
                       <input id="lead-email" class="form-control" name="email">
                     </div>
-                        <div class="col-md-4">
+                        <div class="col-md-6">
                           <label class="form-label">Phone</label>
                           <input id="lead-phone" class="form-control" name="phone">
                         </div>
-                        <div class="col-md-4">
+                        <div class="col-md-6">
                           <label class="form-label">Source</label>
                           <input id="lead-source" class="form-control" name="source">
                         </div>
@@ -296,15 +296,15 @@
                           <label class="form-label">Notes</label>
                           <textarea id="lead-notes" class="form-control" name="notes"></textarea>
                         </div>
-                        <div class="col-md-4">
+                        <div class="col-md-6">
                           <label class="form-label">Agent</label>
                           <input id="lead-agent" class="form-control" name="agent">
                         </div>
-                        <div class="col-md-4">
+                        <div class="col-md-6">
                           <label class="form-label">Revenue Yearly</label>
                           <input type="number" id="lead-revenue-yearly" class="form-control" name="revenueYearly">
                         </div>
-                        <div class="col-md-4">
+                        <div class="col-md-6">
                           <label class="form-label">Importance</label>
                           <select id="lead-importance" class="form-select" name="importance">
                             <option value="high">High</option>
@@ -312,7 +312,7 @@
                             <option value="low">Low</option>
                           </select>
                         </div>
-                        <div class="col-md-4">
+                        <div class="col-md-6">
                           <label class="form-label">Status</label>
                           <select id="lead-status" class="form-select" name="status">
                             <option value="document upload">Document Upload</option>
@@ -322,53 +322,53 @@
                             <option value="approved">Approved</option>
                           </select>
                         </div>
-                        <div class="col-md-4">
+                        <div class="col-md-6">
                           <label class="form-label">Acquiring Bank</label>
                           <input id="lead-acquiring-bank" class="form-control" name="acquiringBank">
                         </div>
-                        <div class="col-md-4 d-flex align-items-center">
+                        <div class="col-md-6 d-flex align-items-center">
                           <div class="form-check ms-2">
                             <input class="form-check-input" type="checkbox" id="lead-docs-uploaded" name="docsUploaded">
                             <label class="form-check-label" for="lead-docs-uploaded">Docs Uploaded</label>
                           </div>
                         </div>
-                        <div class="col-md-4 d-flex align-items-center">
+                        <div class="col-md-6 d-flex align-items-center">
                           <div class="form-check ms-2">
                             <input class="form-check-input" type="checkbox" id="lead-application-signed" name="applicationSigned">
                             <label class="form-check-label" for="lead-application-signed">Application Signed</label>
                           </div>
                         </div>
-                        <div class="col-md-4">
+                        <div class="col-md-6">
                           <label class="form-label">Underwriting Status</label>
                           <input id="lead-underwriting-status" class="form-control" name="underwritingStatus">
                         </div>
-                        <div class="col-md-4 d-flex align-items-center">
+                        <div class="col-md-6 d-flex align-items-center">
                           <div class="form-check ms-2">
                             <input class="form-check-input" type="checkbox" id="lead-var-sheet-uploaded" name="varSheetUploaded">
                             <label class="form-check-label" for="lead-var-sheet-uploaded">VAR Sheet Uploaded</label>
                           </div>
                         </div>
-                        <div class="col-md-4">
+                        <div class="col-md-6">
                           <label class="form-label">NMI API Key</label>
                           <input id="lead-nmi-api-key" class="form-control" name="nmiApiKey">
                         </div>
-                        <div class="col-md-4 d-flex align-items-center">
+                        <div class="col-md-6 d-flex align-items-center">
                           <div class="form-check ms-2">
                             <input class="form-check-input" type="checkbox" id="lead-transacting" name="transacting">
                             <label class="form-check-label" for="lead-transacting">Transacting</label>
                           </div>
                         </div>
-                        <div class="col-md-4 d-flex align-items-center">
+                        <div class="col-md-6 d-flex align-items-center">
                           <div class="form-check ms-2">
                             <input class="form-check-input" type="checkbox" id="lead-residuals-uploaded" name="residualsUploaded">
                             <label class="form-check-label" for="lead-residuals-uploaded">Residuals Uploaded</label>
                           </div>
                         </div>
-                        <div class="col-md-4">
+                        <div class="col-md-6">
                           <label class="form-label">Residual Audit Status</label>
                           <input id="lead-residual-audit-status" class="form-control" name="residualAuditStatus">
                         </div>
-                        <div class="col-md-4">
+                        <div class="col-md-6">
                           <label class="form-label">Chargebacks</label>
                           <input type="number" id="lead-chargebacks" class="form-control" name="chargebacks">
                         </div>


### PR DESCRIPTION
## Summary
- make the lead panel wider
- arrange lead fields in two columns

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*
- `npm run start` *(fails: cannot find module express)*

------
https://chatgpt.com/codex/tasks/task_e_685c08b47060832eb74efc645710a329