### PR TITLE
Update UI theme and add logo

### DIFF
--- a/backend/public/index.html
+++ b/backend/public/index.html
@@ -12,14 +12,14 @@
     body {
       overflow-x: hidden;
       font-family: 'Inter', sans-serif;
-      background-color: #f9fafb;
+      background-color: #eef3f8;
       color: #374151;
       font-size: 0.8125rem;
     }
 
     #sidebar {
       min-height: 100vh;
-      background-color: #f3f4f6;
+      background-color: #343a40;
       border-right: 1px solid #e5e7eb;
     }
 
@@ -34,7 +34,7 @@
     }
 
     #sidebar .nav-link {
-      color: #6b7280;
+      color: #f8f9fa;
       display: flex;
       align-items: center;
       padding: 10px 15px;
@@ -92,7 +92,7 @@
     #lead-stages .col {
       flex: 0 0 180px;
       width: 180px;
-      background-color: #f9fafb;
+      background-color: #ffffff;
       border-radius: 8px;
       padding: 10px;
       border: 1px solid #e5e7eb;
@@ -175,8 +175,9 @@
 </head>
 <body>
 <nav class="navbar navbar-expand-lg navbar-light bg-white border-bottom mb-4 shadow-sm">
-  <div class="container-fluid">
-    <a class="navbar-brand" href="#">ISO Tracker</a>
+  <div class="container-fluid d-flex align-items-center">
+    <span class="navbar-brand me-auto">ISO Tracker</span>
+    <img src="/logo.svg" alt="ISO Tracker Logo" class="ms-auto" style="height:30px;">
   </div>
 </nav>
 <div class="container-fluid">

--- a/backend/public/logo.svg
+++ b/backend/public/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" rx="20" fill="#10a37f" />
+  <path d="M30 52 L45 67 L70 42" fill="none" stroke="#fff" stroke-width="10" stroke-linecap="round" stroke-linejoin="round" />
+</svg>


### PR DESCRIPTION
## Summary
- change sidebar to dark grey and lighten body background
- keep lead and window boxes white
- show a logo in the navbar and store it in the repo

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685c0b6da700832e977596555035616c