### PR TITLE
Fix layout of lead gauges and panel

### DIFF
--- a/backend/public/index.html
+++ b/backend/public/index.html
@@ -100,6 +100,11 @@
       position: relative;
     }
 
+    #lead-gauges .col {
+      flex: 0 0 180px;
+      width: 180px;
+    }
+
     #lead-stages .col ul {
       min-height: 80px;
     }
@@ -156,7 +161,7 @@
       padding: 10px;
       overflow: visible;
       margin-right: 2rem;
-      margin-top: -120px;
+      margin-top: 0;
       font-size: 0.8125rem;
     }
 
@@ -222,49 +227,61 @@
 
           <div id="lead-interface" class="d-flex gap-3">
             <div id="lead-stages-container" class="flex-grow-1">
-              <div class="row text-center" id="lead-stages">
+              <div id="lead-gauges" class="row text-center mb-2">
                 <div class="col d-flex flex-column align-items-center">
-                  <div class="gauge-container position-relative text-center mb-2">
+                  <div class="gauge-container position-relative text-center">
                     <canvas id="gauge-document-upload" width="100" height="100"></canvas>
                     <div class="gauge-percentage position-absolute top-50 start-50 translate-middle"></div>
                     <div class="small mt-1" id="label-document-upload"></div>
                   </div>
-                  <h5>Document Upload</h5>
-                  <ul class="list-group" id="stage-document-upload"></ul>
                 </div>
                 <div class="col d-flex flex-column align-items-center">
-                  <div class="gauge-container position-relative text-center mb-2">
+                  <div class="gauge-container position-relative text-center">
                     <canvas id="gauge-application" width="100" height="100"></canvas>
                     <div class="gauge-percentage position-absolute top-50 start-50 translate-middle"></div>
                     <div class="small mt-1" id="label-application"></div>
                   </div>
-                  <h5>Application</h5>
-                  <ul class="list-group" id="stage-application"></ul>
                 </div>
                 <div class="col d-flex flex-column align-items-center">
-                  <div class="gauge-container position-relative text-center mb-2">
+                  <div class="gauge-container position-relative text-center">
                     <canvas id="gauge-pending" width="100" height="100"></canvas>
                     <div class="gauge-percentage position-absolute top-50 start-50 translate-middle"></div>
                     <div class="small mt-1" id="label-pending"></div>
                   </div>
-                  <h5>Pending</h5>
-                  <ul class="list-group" id="stage-pending"></ul>
                 </div>
                 <div class="col d-flex flex-column align-items-center">
-                  <div class="gauge-container position-relative text-center mb-2">
+                  <div class="gauge-container position-relative text-center">
                     <canvas id="gauge-cancelled" width="100" height="100"></canvas>
                     <div class="gauge-percentage position-absolute top-50 start-50 translate-middle"></div>
                     <div class="small mt-1" id="label-cancelled"></div>
                   </div>
-                  <h5>Cancelled</h5>
-                  <ul class="list-group" id="stage-cancelled"></ul>
                 </div>
                 <div class="col d-flex flex-column align-items-center">
-                  <div class="gauge-container position-relative text-center mb-2">
+                  <div class="gauge-container position-relative text-center">
                     <canvas id="gauge-approved" width="100" height="100"></canvas>
                     <div class="gauge-percentage position-absolute top-50 start-50 translate-middle"></div>
                     <div class="small mt-1" id="label-approved"></div>
                   </div>
+                </div>
+              </div>
+              <div class="row text-center" id="lead-stages">
+                <div class="col d-flex flex-column align-items-center">
+                  <h5>Document Upload</h5>
+                  <ul class="list-group" id="stage-document-upload"></ul>
+                </div>
+                <div class="col d-flex flex-column align-items-center">
+                  <h5>Application</h5>
+                  <ul class="list-group" id="stage-application"></ul>
+                </div>
+                <div class="col d-flex flex-column align-items-center">
+                  <h5>Pending</h5>
+                  <ul class="list-group" id="stage-pending"></ul>
+                </div>
+                <div class="col d-flex flex-column align-items-center">
+                  <h5>Cancelled</h5>
+                  <ul class="list-group" id="stage-cancelled"></ul>
+                </div>
+                <div class="col d-flex flex-column align-items-center">
                   <h5>Approved</h5>
                   <ul class="list-group" id="stage-approved"></ul>
                 </div>


### PR DESCRIPTION
## Summary
- separate the lead progress gauges into their own row
- keep the gauges centered above the lead stage columns
- remove the negative margin so the lead form panel is fully visible

## Testing
- `npm install`
- `node backend/server.js` *(fails to connect to MongoDB but server starts)*

------
https://chatgpt.com/codex/tasks/task_e_685c0f3aec2c832e814b3bc1e81956e7