### PR TITLE
Fix Add Lead button layout

### DIFF
--- a/backend/public/index.html
+++ b/backend/public/index.html
@@ -171,7 +171,7 @@
     }
 
     #lead-interface {
-      display: inline-flex !important;
+      display: flex !important;
       align-items: flex-start;
       flex-wrap: wrap;
     }
@@ -223,7 +223,7 @@
         </div>
         <div id="leads-section" class="content-section">
           <h2>Leads</h2>
-          <button id="show-add-lead" class="btn btn-primary mb-3">Add Lead</button>
+          <button id="show-add-lead" class="btn btn-primary btn-sm mb-3 d-block">Add Lead</button>
 
           <div id="lead-interface" class="d-flex gap-3">
             <div id="lead-stages-container" class="flex-grow-1">


### PR DESCRIPTION
## Summary
- ensure the Add Lead button is placed below the `Leads` heading
- make the button smaller
- keep lead stages layout block-level so it doesn't appear inline with the button

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685c14fa53d0832e9255f237b3b0cacc