### PR TITLE
Fix lead card width

### DIFF
--- a/backend/public/index.html
+++ b/backend/public/index.html
@@ -120,6 +120,9 @@
       border: 1px solid #e5e7eb;
       border-left-width: 6px;
       border-radius: 6px;
+      width: 100%;
+      display: flex;
+      flex-direction: column;
       padding: 6px;
       margin-bottom: 8px;
       box-shadow: 0 1px 2px rgba(0,0,0,0.05);


### PR DESCRIPTION
## Summary
- keep lead cards full width by default

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685c193ec654832e98e66d9bb88bcda0