### PR TITLE
Add padding between sidebar and lead content

### DIFF
--- a/backend/public/index.html
+++ b/backend/public/index.html
@@ -30,6 +30,7 @@
       }
       #main-content {
         flex: 1;
+        padding-left: 1rem;
       }
     }
 


### PR DESCRIPTION
## Summary
- add left padding to `#main-content` so that the Leads page content doesn't butt up against the left menu

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685c20dd8b88832ea6a6087305f07bca