### PR TITLE
Add Processor database and table

### DIFF
--- a/backend/models/Processor.js
+++ b/backend/models/Processor.js
@@ -1,0 +1,12 @@
+import mongoose from 'mongoose';
+
+const processorSchema = new mongoose.Schema({
+  name: { type: String, required: true },
+  isoSplit: Number,
+  contact: String,
+  phone: String,
+  email: String,
+  notes: String
+}, { timestamps: true });
+
+export default mongoose.model('Processor', processorSchema);

--- a/backend/public/index.html
+++ b/backend/public/index.html
@@ -198,6 +198,7 @@
         <li class="nav-item"><a class="nav-link active" href="#" data-target="home-section"><i class="fas fa-home"></i><span class="ms-2">Home</span></a></li>
         <li class="nav-item"><a class="nav-link" href="#" data-target="leads-section"><i class="fas fa-user-plus"></i><span class="ms-2">Leads</span></a></li>
         <li class="nav-item"><a class="nav-link" href="#" data-target="merchants-section"><i class="fas fa-store"></i><span class="ms-2">Merchants</span></a></li>
+        <li class="nav-item"><a class="nav-link" href="#" data-target="processors-section"><i class="fas fa-cogs"></i><span class="ms-2">Processors</span></a></li>
         <li class="nav-item"><a class="nav-link" href="#" data-target="residuals-section"><i class="fas fa-money-bill-wave"></i><span class="ms-2">Residuals</span></a></li>
       </ul>
     </nav>
@@ -433,6 +434,17 @@
           <tbody></tbody>
         </table>
       </div>
+      <div id="processors-section" class="content-section">
+        <h2>Processors</h2>
+        <table class="table table-hover" id="processors-table">
+          <thead class="table-light">
+            <tr>
+              <th>Name</th><th>ISO Split %</th><th>Contact</th><th>Phone</th><th>Email</th><th>Notes</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </div>
       <div id="residuals-section" class="content-section">
         <h2>Residuals</h2>
         <p>Upload residual reports and calculate splits.</p>
@@ -649,6 +661,24 @@ async function loadMerchants() {
   updateDashboardMerchants(merchants);
 }
 
+async function loadProcessors() {
+  const res = await fetch('/api/processors');
+  const processors = await res.json();
+  const tbody = document.querySelector('#processors-table tbody');
+  tbody.innerHTML = '';
+  processors.forEach(p => {
+    const row = document.createElement('tr');
+    row.innerHTML = `
+      <td>${p.name}</td>
+      <td>${p.isoSplit ?? ''}</td>
+      <td>${p.contact || ''}</td>
+      <td>${p.phone || ''}</td>
+      <td>${p.email || ''}</td>
+      <td>${p.notes || ''}</td>`;
+    tbody.appendChild(row);
+  });
+}
+
 document.querySelectorAll('#sidebar .nav-link').forEach(link => {
   link.addEventListener('click', (e) => {
     e.preventDefault();
@@ -718,6 +748,7 @@ document.getElementById('delete-lead').addEventListener('click', async () => {
 
 loadLeads();
 loadMerchants();
+loadProcessors();
 </script>
 </body>
 </html>

--- a/backend/routes/processors.js
+++ b/backend/routes/processors.js
@@ -1,0 +1,42 @@
+import express from 'express';
+import mongoose from 'mongoose';
+import Processor from '../models/Processor.js';
+
+const router = express.Router();
+
+router.get('/', async (req, res) => {
+  if (req.app.locals.useMemoryDB) {
+    res.json(req.app.locals.memoryProcessors);
+  } else {
+    const processors = await Processor.find();
+    res.json(processors);
+  }
+});
+
+router.post('/', async (req, res) => {
+  if (req.app.locals.useMemoryDB) {
+    const processor = { _id: new mongoose.Types.ObjectId().toString(), ...req.body };
+    req.app.locals.memoryProcessors.push(processor);
+    res.json(processor);
+  } else {
+    const processor = new Processor(req.body);
+    await processor.save();
+    res.json(processor);
+  }
+});
+
+router.patch('/:id', async (req, res) => {
+  const { id } = req.params;
+  if (req.app.locals.useMemoryDB) {
+    const processors = req.app.locals.memoryProcessors;
+    const index = processors.findIndex(p => p._id === id);
+    if (index === -1) return res.status(404).json({ error: 'Not found' });
+    processors[index] = { ...processors[index], ...req.body };
+    res.json(processors[index]);
+  } else {
+    const processor = await Processor.findByIdAndUpdate(id, req.body, { new: true });
+    res.json(processor);
+  }
+});
+
+export default router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'url';
 import dotenv from 'dotenv';
 import leadRoutes from './routes/leads.js';
 import merchantRoutes from './routes/merchants.js';
+import processorRoutes from './routes/processors.js';
 
 dotenv.config();
 
@@ -19,6 +20,7 @@ app.use(express.static(path.join(__dirname, 'public')));
 
 app.use('/api/leads', leadRoutes);
 app.use('/api/merchants', merchantRoutes);
+app.use('/api/processors', processorRoutes);
 
 app.get('/', (req, res) => {
   res.sendFile(path.join(__dirname, 'public', 'index.html'));
@@ -36,6 +38,7 @@ const MONGO_URI =
 app.locals.useMemoryDB = true;
 app.locals.memoryLeads = [];
 app.locals.memoryMerchants = [];
+app.locals.memoryProcessors = [];
 
 async function connectAndStart() {
   if (MONGO_URI && !MONGO_URI.includes('<db_password>')) {


### PR DESCRIPTION
## Summary
- create Processor model and API routes
- wire up processor routes in server and memory DB
- add Processors navigation and table to dashboard
- load processor data in frontend

## Testing
- `npm install`
- `npm start` *(fails to connect to MongoDB but starts with in-memory store)*

------
https://chatgpt.com/codex/tasks/task_e_685c2c2337d4832eac1929ed38b03210