### PR TITLE
Update merchant model and auto-convert approved leads

### DIFF
--- a/backend/models/Merchant.js
+++ b/backend/models/Merchant.js
@@ -6,6 +6,11 @@ const merchantSchema = new mongoose.Schema({
   mid: String,
   mcc: String,
   mtdVolume: Number,
+  volume: {
+    daily: { type: Number, default: 0 },
+    weekly: { type: Number, default: 0 },
+    ytd: { type: Number, default: 0 }
+  },
   processor: String,
   status: String,
   agent: String,

--- a/backend/routes/leads.js
+++ b/backend/routes/leads.js
@@ -18,7 +18,9 @@ router.post('/', async (req, res) => {
   if (req.app.locals.useMemoryDB) {
     const lead = { _id: new mongoose.Types.ObjectId().toString(), ...req.body };
     req.app.locals.memoryLeads.push(lead);
-    if (lead.approved) {
+    const isApproved = lead.status === 'approved' || lead.approved;
+    if (isApproved) {
+      lead.approved = true;
       const exists = req.app.locals.memoryMerchants.find(
         m => m.name === lead.name && m.email === lead.email
       );
@@ -32,7 +34,8 @@ router.post('/', async (req, res) => {
           nmiApiKey: lead.nmiApiKey,
           transactionFee: lead.transactionFee,
           authorizationFee: lead.authorizationFee,
-          pricingModel: lead.pricingModel
+          pricingModel: lead.pricingModel,
+          status: 'approved'
         };
         req.app.locals.memoryMerchants.push(merchant);
       }
@@ -41,7 +44,9 @@ router.post('/', async (req, res) => {
   } else {
     const lead = new Lead(req.body);
     await lead.save();
-    if (lead.approved) {
+    const isApproved = lead.status === 'approved' || lead.approved;
+    if (isApproved) {
+      lead.approved = true;
       const exists = await Merchant.findOne({
         name: lead.name,
         email: lead.email
@@ -55,7 +60,8 @@ router.post('/', async (req, res) => {
           nmiApiKey: lead.nmiApiKey,
           transactionFee: lead.transactionFee,
           authorizationFee: lead.authorizationFee,
-          pricingModel: lead.pricingModel
+          pricingModel: lead.pricingModel,
+          status: 'approved'
         });
         await merchant.save();
       }
@@ -72,7 +78,9 @@ router.patch('/:id', async (req, res) => {
     if (index === -1) return res.status(404).json({ error: 'Not found' });
     leads[index] = { ...leads[index], ...req.body };
     const lead = leads[index];
-    if (lead.approved) {
+    const isApproved = lead.status === 'approved' || lead.approved;
+    if (isApproved) {
+      lead.approved = true;
       const exists = req.app.locals.memoryMerchants.find(
         m => m.name === lead.name && m.email === lead.email
       );
@@ -86,7 +94,8 @@ router.patch('/:id', async (req, res) => {
           nmiApiKey: lead.nmiApiKey,
           transactionFee: lead.transactionFee,
           authorizationFee: lead.authorizationFee,
-          pricingModel: lead.pricingModel
+          pricingModel: lead.pricingModel,
+          status: 'approved'
         };
         req.app.locals.memoryMerchants.push(merchant);
       }
@@ -94,7 +103,9 @@ router.patch('/:id', async (req, res) => {
     res.json(lead);
   } else {
     const lead = await Lead.findByIdAndUpdate(id, req.body, { new: true });
-    if (lead && lead.approved) {
+    const isApproved = lead && (lead.status === 'approved' || lead.approved);
+    if (isApproved) {
+      lead.approved = true;
       const exists = await Merchant.findOne({
         name: lead.name,
         email: lead.email
@@ -108,7 +119,8 @@ router.patch('/:id', async (req, res) => {
           nmiApiKey: lead.nmiApiKey,
           transactionFee: lead.transactionFee,
           authorizationFee: lead.authorizationFee,
-          pricingModel: lead.pricingModel
+          pricingModel: lead.pricingModel,
+          status: 'approved'
         });
         await merchant.save();
       }

--- a/backend/routes/merchants.js
+++ b/backend/routes/merchants.js
@@ -15,11 +15,18 @@ router.get('/', async (req, res) => {
 
 router.post('/', async (req, res) => {
   if (req.app.locals.useMemoryDB) {
-    const merchant = { _id: new mongoose.Types.ObjectId().toString(), ...req.body };
+    const merchant = {
+      _id: new mongoose.Types.ObjectId().toString(),
+      volume: { daily: 0, weekly: 0, ytd: 0 },
+      ...req.body
+    };
     req.app.locals.memoryMerchants.push(merchant);
     res.json(merchant);
   } else {
-    const merchant = new Merchant(req.body);
+    const merchant = new Merchant({
+      volume: { daily: 0, weekly: 0, ytd: 0 },
+      ...req.body
+    });
     await merchant.save();
     res.json(merchant);
   }


### PR DESCRIPTION
## Summary
- track daily, weekly and yearly volume on merchants
- create default volume when merchants are created
- convert leads to merchants when their status becomes `approved`

## Testing
- `npm start`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685c437257b4832e9912d3ce70e412d4