### PR TITLE
Add periodic dashboard refresh

### DIFF
--- a/backend/public/index.html
+++ b/backend/public/index.html
@@ -867,6 +867,13 @@ document.getElementById('delete-processor').addEventListener('click', async () =
 loadLeads();
 loadMerchants();
 loadProcessors();
+
+// Periodically refresh data every 15 seconds to keep the dashboard in sync
+setInterval(() => {
+  loadLeads();
+  loadMerchants();
+  loadProcessors();
+}, 15000);
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- automatically reload data to update merchant and lead dashboards

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_685c6b494748832e9e47bd2396f9df68