### PR TITLE
Fix processor page layout

### DIFF
--- a/backend/public/index.html
+++ b/backend/public/index.html
@@ -183,6 +183,15 @@
       flex-wrap: wrap;
     }
 
+    #processor-interface {
+      display: flex;
+      align-items: flex-start;
+    }
+
+    #processor-table-wrapper {
+      flex: 0 0 calc(100% - 512px);
+    }
+
   </style>
 </head>
 <body>
@@ -538,7 +547,7 @@
         <h2>Processors</h2>
         <button id="show-add-processor" class="btn btn-primary btn-sm mb-3 d-block">Add Processor</button>
         <div id="processor-interface" class="d-flex gap-3">
-          <div class="flex-grow-1">
+          <div id="processor-table-wrapper">
             <table class="table table-hover" id="processors-table">
               <thead class="table-light">
                 <tr>


### PR DESCRIPTION
## Summary
- keep processor table width constant by using a fixed wrapper
- style processor interface so right panel doesn't resize table

## Testing
- `npm install`
- `npm start` *(fails to connect to MongoDB but server starts)*

------
https://chatgpt.com/codex/tasks/task_e_685c7e4a6628832eb1db156bdec7da9f